### PR TITLE
feat: add dashboard interaction scripts

### DIFF
--- a/dashboard/assets/js/dashboard.js
+++ b/dashboard/assets/js/dashboard.js
@@ -1,0 +1,131 @@
+// Dashboard interactions and utilities
+// Handles navigation toggles, service modals and clipboard helpers
+
+(function () {
+    'use strict';
+
+    // Ensure DOM is ready
+    document.addEventListener('DOMContentLoaded', () => {
+        setupNavigation();
+        setupDropdowns();
+    });
+
+    function setupNavigation() {
+        const navToggle = document.getElementById('navToggle');
+        const navMenu = document.getElementById('navMenu');
+        if (!navToggle || !navMenu) return;
+
+        navToggle.addEventListener('click', () => {
+            navMenu.classList.toggle('active');
+            navToggle.classList.toggle('active');
+        });
+    }
+
+    function setupDropdowns() {
+        const dropdownItems = document.querySelectorAll('.nav-item.dropdown');
+        const menus = document.querySelectorAll('.dropdown-menu');
+
+        const closeAll = () => {
+            dropdownItems.forEach(item => item.classList.remove('open'));
+            menus.forEach(menu => menu.classList.remove('active'));
+        };
+
+        dropdownItems.forEach(item => {
+            const menu = document.getElementById(item.dataset.dropdown);
+            if (!menu) return;
+
+            item.addEventListener('click', e => {
+                e.stopPropagation();
+                const isOpen = item.classList.contains('open');
+                closeAll();
+                if (!isOpen) {
+                    item.classList.add('open');
+                    menu.classList.add('active');
+                }
+            });
+        });
+
+        document.addEventListener('click', closeAll);
+    }
+
+    // Smooth scroll helper used by buttons
+    window.scrollToSection = function (id) {
+        const target = document.getElementById(id);
+        if (target) {
+            target.scrollIntoView({ behavior: 'smooth' });
+        }
+    };
+
+    // Service modal management
+    const serviceMap = {
+        ats: {
+            title: 'Zex ATS AI',
+            url: 'http://localhost:8000/'
+        },
+        website: {
+            title: 'Dynamic Website Generator',
+            url: 'http://localhost:8080/'
+        }
+    };
+
+    window.openService = function (service) {
+        const cfg = serviceMap[service];
+        const modal = document.getElementById('serviceModal');
+        const frame = document.getElementById('serviceFrame');
+        const title = document.getElementById('modalTitle');
+        if (!cfg || !modal || !frame || !title) return;
+
+        title.textContent = cfg.title;
+        frame.src = cfg.url;
+        modal.classList.add('active');
+    };
+
+    window.closeModal = function () {
+        const modal = document.getElementById('serviceModal');
+        const frame = document.getElementById('serviceFrame');
+        if (modal) modal.classList.remove('active');
+        if (frame) frame.src = '';
+    };
+
+    // Endpoint copy helper
+    const endpointMap = {
+        ats: 'http://localhost:8000/api/v1/analyze',
+        website: 'http://localhost:8080/api/v1/upload'
+    };
+
+    window.copyEndpoint = function (type) {
+        const endpoint = endpointMap[type];
+        if (!endpoint) return;
+
+        const copyPromise = navigator.clipboard
+            ? navigator.clipboard.writeText(endpoint)
+            : legacyCopy(endpoint);
+
+        copyPromise
+            .then(() => showCopyFeedback())
+            .catch(() => showCopyFeedback());
+    };
+
+    function legacyCopy(text) {
+        return new Promise(resolve => {
+            const temp = document.createElement('textarea');
+            temp.value = text;
+            temp.setAttribute('readonly', '');
+            temp.style.position = 'absolute';
+            temp.style.left = '-9999px';
+            document.body.appendChild(temp);
+            temp.select();
+            document.execCommand('copy');
+            document.body.removeChild(temp);
+            resolve();
+        });
+    }
+
+    function showCopyFeedback() {
+        const btn = window.event ? window.event.currentTarget : null;
+        if (!btn) return;
+        btn.classList.add('copied');
+        setTimeout(() => btn.classList.remove('copied'), 2000);
+    }
+})();
+

--- a/dashboard/assets/js/theme.js
+++ b/dashboard/assets/js/theme.js
@@ -1,0 +1,31 @@
+// Theme management: toggle between light and dark modes and persist preference
+(function () {
+    'use strict';
+
+    const storageKey = 'dashboard-theme';
+
+    document.addEventListener('DOMContentLoaded', () => {
+        const saved = localStorage.getItem(storageKey);
+        if (saved) {
+            applyTheme(saved);
+        } else {
+            const initial = document.body.getAttribute('data-theme') || 'light';
+            applyTheme(initial);
+        }
+
+        const toggle = document.getElementById('themeToggle');
+        if (toggle) {
+            toggle.addEventListener('click', () => {
+                const current = document.body.getAttribute('data-theme') === 'dark' ? 'light' : 'dark';
+                applyTheme(current);
+            });
+        }
+    });
+
+    function applyTheme(theme) {
+        document.body.setAttribute('data-theme', theme);
+        document.body.className = 'theme-' + theme;
+        localStorage.setItem(storageKey, theme);
+    }
+})();
+


### PR DESCRIPTION
## Summary
- add dashboard.js to handle navigation, service modals, and endpoint copy helpers
- add theme.js to toggle light/dark modes with persistence

## Testing
- `node --check ATS_Checker-Enhancer/dashboard/assets/js/dashboard.js && node --check ATS_Checker-Enhancer/dashboard/assets/js/theme.js`


------
https://chatgpt.com/codex/tasks/task_e_68c193184964832392498a1ec67233d7