### PR TITLE
feat: make contact endpoint configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -976,6 +976,8 @@ Yes, I'd like to add those extras! Here's quick additions:
   ```
   Netlify auto-detects and handles forms (emails to you).
 
+- **Custom Contact Endpoint**: The portfolio's contact form can submit to a custom backend. Set the `data-endpoint` attribute on the form or define a `CONTACT_FORM_ENDPOINT` global variable to point to your API route (defaults to `/api/contact`). Implement a `POST /api/contact` endpoint in your backend to handle these submissions.
+
 - **Google Analytics**: Add this to <head> in index.html (replace UA-XXXXX-Y with your tracking ID):
   ```html
   <script async src="https://www.googletagmanager.com/gtag/js?id=UA-XXXXX-Y"></script>

--- a/website/index.html
+++ b/website/index.html
@@ -223,7 +223,7 @@
                     </div>
                     
                     <div class="contact-form-container">
-                        <form class="contact-form" id="contact-form" name="contact" method="POST" data-netlify="true">
+                        <form class="contact-form" id="contact-form" name="contact" method="POST" data-netlify="true" data-endpoint="/api/contact">
                             <input type="hidden" name="form-name" value="contact">
                             
                             <div class="form-group">

--- a/website/js/app.js
+++ b/website/js/app.js
@@ -209,8 +209,12 @@ function initializeContactForm() {
             submitButton.disabled = true;
             
             try {
-                // If using Netlify forms
-                const response = await fetch('/', {
+                // Determine submission endpoint
+                const apiEndpoint = contactForm.getAttribute('data-endpoint') ||
+                    window.CONTACT_FORM_ENDPOINT || '/api/contact';
+
+                // Submit form data to configured endpoint (expects POST /api/contact)
+                const response = await fetch(apiEndpoint, {
                     method: 'POST',
                     headers: { "Content-Type": "application/x-www-form-urlencoded" },
                     body: encode({
@@ -228,7 +232,11 @@ function initializeContactForm() {
                 
             } catch (error) {
                 console.error('Error submitting form:', error);
-                showError('Failed to send message. Please try again or contact me directly.');
+                if (error instanceof TypeError) {
+                    showError('Network error. Please check your connection and try again.');
+                } else {
+                    showError('Failed to send message. Please try again or contact me directly.');
+                }
             } finally {
                 // Restore button state
                 submitButton.innerHTML = originalText;


### PR DESCRIPTION
## Summary
- allow setting contact form API endpoint via data attribute or `CONTACT_FORM_ENDPOINT`
- handle network errors during contact form submission
- document required POST `/api/contact` backend route

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c1932d60ec8323949090a6199046a1