### PR TITLE
fix: support direct calls in job handlers

### DIFF
--- a/sandbox/README.md
+++ b/sandbox/README.md
@@ -46,6 +46,8 @@ function findMatchingJobs() {
 // Additional interactive features...
 ```
 
+Note: Event handlers such as `findJobs` and `findMatchingJobs` resolve the button element with `event?.target || this` so they can be invoked via DOM events or direct function calls.
+
 ## 🎯 Demo Features
 
 ### Interactive Resume Analysis

--- a/sandbox/index.html
+++ b/sandbox/index.html
@@ -713,7 +713,7 @@
             const resultsDiv = document.getElementById('job-results');
             
             // Show loading effect
-            const button = event.target;
+            const button = event?.target || this; // Use event target or fallback for flexibility
             const originalText = button.innerHTML;
             button.innerHTML = '<i class="fas fa-spinner fa-spin"></i> Searching...';
             button.disabled = true;

--- a/sandbox/script.js
+++ b/sandbox/script.js
@@ -82,7 +82,7 @@ function showInsights() {
 
 // Job Matching Demo
 function findMatchingJobs() {
-    const button = event.target;
+    const button = event?.target || this; // Support calls without event context
     const originalText = button.innerHTML;
     
     button.innerHTML = '<i class="fas fa-spinner fa-spin"></i> AI Processing...';


### PR DESCRIPTION
## Summary
- handle missing event object in `findJobs` and `findMatchingJobs` by falling back to `this`
- document button resolution behavior for sandbox maintainers

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c19453cde88323ac43457e8a81385a