### PR TITLE
docs: document base URL configuration

### DIFF
--- a/DEPLOYMENT_GUIDE.md
+++ b/DEPLOYMENT_GUIDE.md
@@ -197,6 +197,23 @@ The universal deployment script automatically configures:
 - `MAX_FILE_SIZE`: 50MB desktop, 10MB mobile
 - `SUPPORTED_FORMATS`: All formats or mobile-optimized subset
 
+### **Base URL Configuration**
+
+`BASE_URL` defines the root path served by the dashboard frontend. Deployment scripts like `deploy.sh` or `deploy_web.py` replace a `__BASE_URL__` placeholder in `dashboard/index.html` with this value before publishing.
+
+**Sample values**
+
+- Local: `BASE_URL=http://localhost:8000`
+- Staging: `BASE_URL=https://staging.example.com`
+- Production: `BASE_URL=https://example.com`
+
+**Deployment**
+
+```bash
+export BASE_URL=https://staging.example.com
+./deploy.sh  # script injects BASE_URL into dashboard/index.html
+```
+
 ### **Platform Optimizations**
 - **Desktop**: Full feature set with Docker orchestration
 - **Mobile**: Battery-efficient processing with reduced features

--- a/README.md
+++ b/README.md
@@ -224,6 +224,23 @@ JWT_SECRET_KEY=your-jwt-secret
 ALLOWED_ORIGINS=http://localhost:3000
 ```
 
+### Base URL Configuration
+
+`BASE_URL` defines the root path used by the dashboard’s frontend. Deployment scripts such as `deploy.sh` or `deploy_web.py` replace a `__BASE_URL__` placeholder in `dashboard/index.html` with this value before publishing.
+
+**Sample values**
+
+- Local: `BASE_URL=http://localhost:8000`
+- Staging: `BASE_URL=https://staging.example.com`
+- Production: `BASE_URL=https://example.com`
+
+**Deployment**
+
+```bash
+export BASE_URL=https://staging.example.com
+./deploy.sh  # script injects BASE_URL into dashboard/index.html
+```
+
 ### Database Schema
 
 The application uses PostgreSQL with the following core tables:


### PR DESCRIPTION
## Summary
- document how BASE_URL drives dashboard root path and deployment placeholder substitution
- mirror base URL guidance in deployment guide for consistency

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c1955b4ab083239c04d2e0d15eb433